### PR TITLE
build: remove Microsoft.NETCore.App since it is included on net8

### DIFF
--- a/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
+++ b/Application/EdFi.Ods.AdminApi/EdFi.Ods.AdminApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
@@ -36,7 +36,6 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="8.0.0" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.63.0" />
-    <PackageReference Include="Microsoft.NETCore.App" Version="2.1.30" />
     <PackageReference Include="NJsonSchema" Version="11.0.2" />
     <PackageReference Include="Npgsql" Version="8.0.6" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="4.10.1" />


### PR DESCRIPTION
build: remove Microsoft.NETCore.App since it is included on net8 and deprecated as library